### PR TITLE
feat: Add support for a `date` field type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 				"comapeocat": "bin/comapeocat.mjs"
 			},
 			"devDependencies": {
-				"@comapeo/schema": "^2.1.1",
+				"@comapeo/schema": "^2.3.0",
 				"@eslint/js": "^9.36.0",
 				"@faker-js/faker": "^10.0.0",
 				"@trivago/prettier-plugin-sort-imports": "^5.2.2",
@@ -185,15 +185,15 @@
 			}
 		},
 		"node_modules/@comapeo/schema": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-2.1.1.tgz",
-			"integrity": "sha512-PC5vDrjWPfnNJAmriO5XgtYS2t/1EYVgPJL+jte4apsu+aqK9h1Yut4K9s7KkTWrA/+xTAXiLSYmq15YTbom+A==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-2.3.0.tgz",
+			"integrity": "sha512-W39EqtKHPmnd49KbbMkTCL9YHSeM23h71Dk40BnD1z0RUQyM+HwRr3HFyEv+d3OyH/0BFbUCW0Rg9DBln53WNA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@comapeo/geometry": "^1.1.1",
 				"compact-encoding": "^2.12.0",
-				"protobufjs": "^7.2.5",
+				"protobufjs": "^7.5.5",
 				"type-fest": "^4.26.0"
 			}
 		},
@@ -871,9 +871,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/codegen": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
@@ -885,14 +885,13 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/fetch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.1",
-				"@protobufjs/inquire": "^1.1.0"
+				"@protobufjs/aspromise": "^1.1.1"
 			}
 		},
 		"node_modules/@protobufjs/float": {
@@ -903,9 +902,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+			"integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
@@ -924,9 +923,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/utf8": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
@@ -3312,25 +3311,25 @@
 			"license": "MIT"
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
+			"integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/codegen": "^2.0.5",
 				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.1",
 				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/inquire": "^1.1.2",
 				"@protobufjs/path": "^1.1.2",
 				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
 				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
+				"long": "^5.3.2"
 			},
 			"engines": {
 				"node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"yoctocolors": "^2.1.2"
 	},
 	"devDependencies": {
-		"@comapeo/schema": "^2.1.1",
+		"@comapeo/schema": "^2.3.0",
 		"@eslint/js": "^9.36.0",
 		"@faker-js/faker": "^10.0.0",
 		"@trivago/prettier-plugin-sort-imports": "^5.2.2",

--- a/src/schema/field.js
+++ b/src/schema/field.js
@@ -109,4 +109,8 @@ export const FieldSchema = v.variant('type', [
 		),
 		options: OptionsSchema,
 	}),
+	v.object({
+		...BaseFieldSchema.entries,
+		type: v.pipe(v.literal('date'), v.description('Date picker field')),
+	}),
 ])

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -130,6 +130,11 @@ export const fixtures = /** @type {const} */ ({
 			tagKey: 'width',
 			label: 'Width (m)',
 		},
+		planting_date: {
+			type: 'date',
+			tagKey: 'planting_date',
+			label: 'Planting Date',
+		},
 	},
 
 	categorySelection: {

--- a/test/reader.test.js
+++ b/test/reader.test.js
@@ -213,10 +213,13 @@ describe('Reader', () => {
 					'categories.json': {
 						tree: {
 							...fixtures.categories.tree,
-							fields: ['species'],
+							fields: ['species', 'planting_date'],
 						},
 					},
-					'fields.json': { species: fixtures.fields.species },
+					'fields.json': {
+						species: fixtures.fields.species,
+						planting_date: fixtures.fields.planting_date,
+					},
 					'categorySelection.json': fixtures.categorySelection.observation,
 					'metadata.json': fixtures.metadata.minimal,
 				},
@@ -225,9 +228,10 @@ describe('Reader', () => {
 			const reader = new Reader(filepath)
 			const fields = await reader.fields()
 
-			assert.equal(fields.size, 1)
+			assert.equal(fields.size, 2)
 			assert.equal(fields.get('species')?.type, 'text')
 			assert.equal(fields.get('species')?.label, 'Species')
+			assert.equal(fields.get('planting_date')?.type, 'date')
 
 			await reader.close()
 		})

--- a/test/roundtrip.test.js
+++ b/test/roundtrip.test.js
@@ -43,6 +43,7 @@ describe('Writer -> Reader roundtrip tests', () => {
 		writer.addField('name', fixtures.fields.name)
 		writer.addField('area_size', fixtures.fields.area_size)
 		writer.addField('width', fixtures.fields.width)
+		writer.addField('planting_date', fixtures.fields.planting_date)
 
 		await writer.addIcon('tree', fixtures.icons.tree)
 		await writer.addIcon('forest', fixtures.icons.forest)
@@ -77,7 +78,7 @@ describe('Writer -> Reader roundtrip tests', () => {
 
 		// Verify fields
 		const fields = await reader.fields()
-		assert.equal(fields.size, 6)
+		assert.equal(fields.size, 7)
 
 		assert.deepEqual(fields.get('species'), fixtures.fields.speciesComplete)
 		assert.deepEqual(fields.get('height'), fixtures.fields.height)
@@ -89,6 +90,7 @@ describe('Writer -> Reader roundtrip tests', () => {
 		assert.deepEqual(fields.get('area_size'), fixtures.fields.area_size)
 		assert.deepEqual(fields.get('width'), fixtures.fields.width)
 		assert.deepEqual(fields.get('condition'), fixtures.fields.condition)
+		assert.deepEqual(fields.get('planting_date'), fixtures.fields.planting_date)
 
 		// Verify icons
 		const iconNames = await reader.iconNames()
@@ -279,6 +281,37 @@ describe('Writer -> Reader roundtrip tests', () => {
 		assert.equal(features.type, 'selectMultiple')
 		assert.equal(features.options.length, 3)
 
+		await reader.close()
+	})
+
+	test('roundtrip with date field', async () => {
+		const filepath = join(TEST_DIR, 'roundtrip-date.comapeocat')
+		const writer = createTestWriter()
+
+		writer.addCategory('planting', {
+			name: 'Planting',
+			appliesTo: ['observation', 'track'],
+			tags: { plant: 'yes' },
+			fields: ['planting_date'],
+		})
+		writer.setCategorySelection({
+			observation: ['planting'],
+			track: ['planting'],
+		})
+
+		writer.addField('planting_date', fixtures.fields.planting_date)
+		writer.setMetadata({ name: 'Test' })
+		writer.finish()
+
+		await pipeline(writer.outputStream, createWriteStream(filepath))
+
+		const reader = new Reader(filepath)
+		const fields = await reader.fields()
+		const plantingDate = fields.get('planting_date')
+
+		assert.equal(plantingDate.type, 'date')
+
+		await assert.doesNotReject(() => reader.validate())
 		await reader.close()
 	})
 })

--- a/test/schema.test-d.ts
+++ b/test/schema.test-d.ts
@@ -1,8 +1,8 @@
 import type { PresetValue, FieldValue } from '@comapeo/schema'
 import type { ExtendsStrict } from 'type-fest'
 
-import type { FieldOutput } from '../src/schema/field.js'
 import type { CategoryOutput } from '../src/schema/category.js'
+import type { FieldOutput } from '../src/schema/field.js'
 
 // No schemaName, and refs are strings not objects, without `Ref` or `Refs` suffix
 type Expected<T> = Omit<T, 'schemaName' | `${string}Refs` | `${string}Ref`> & {

--- a/test/writer.test.js
+++ b/test/writer.test.js
@@ -62,6 +62,7 @@ describe('Writer', () => {
 		writer.addField('species', fixtures.fields.species)
 		writer.addField('height', fixtures.fields.height)
 		writer.addField('name', fixtures.fields.name)
+		writer.addField('planting_date', fixtures.fields.planting_date)
 
 		await writer.addIcon('tree', fixtures.icons.tree)
 		await writer.addTranslations('es', fixtures.translations.es)
@@ -89,8 +90,9 @@ describe('Writer', () => {
 		assert.equal(categories.get('tree').color, '#228B22')
 
 		const fields = await reader.fields()
-		assert.equal(fields.size, 3)
+		assert.equal(fields.size, 4)
 		assert.equal(fields.get('species').type, 'text')
+		assert.equal(fields.get('planting_date').type, 'date')
 
 		const iconNames = await reader.iconNames()
 		assert.ok(iconNames.has('tree'))


### PR DESCRIPTION
updates schema to 2.3.0

towards https://github.com/digidem/comapeo-mobile/issues/1817 as it adds `date` to the field validation