### PR TITLE
Feat/lint ci

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -24,5 +24,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
+      - run: npm run lint
       - run: npm run build --if-present
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"test": "node --test",
 		"prepare": "husky && husky install",
 		"format": "prettier --write .",
+		"lint": "prettier --check . && tsc --noEmit -p tsconfig.json",
 		"build:types": "tsc -p tsconfig.npm.json",
 		"build:schema": "node scripts/build-json-schema.mjs",
 		"build": "npm run build:types && npm run build:schema",

--- a/test/schema.test-d.ts
+++ b/test/schema.test-d.ts
@@ -30,7 +30,7 @@ Expect<
 >
 
 // CategoryOutput deliberately diverges from PresetValue: PresetValue.geometry
-// (point/line/area/etc) was replaced with appliesTo (observation/track) in #12
+// (point/line/area/etc) was replaced with appliesTo (observation/track) in https://github.com/digidem/comapeocat/pull/12
 type ExpectedCategory = Omit<Expected<PresetValue>, 'geometry'> & {
 	appliesTo: ('observation' | 'track')[]
 }

--- a/test/schema.test-d.ts
+++ b/test/schema.test-d.ts
@@ -17,7 +17,7 @@ type Expected<T> = Omit<T, 'schemaName' | `${string}Refs` | `${string}Ref`> & {
 			: never
 }
 
-// Check our Except utility type works as intended
+// Check our Expected utility type works as intended
 Expect<
 	ExtendsStrict<
 		{ user: string; orders: string[] },
@@ -28,7 +28,13 @@ Expect<
 		}>
 	>
 >
-Expect<ExtendsStrict<CategoryOutput, Expected<PresetValue>>>
+
+// CategoryOutput deliberately diverges from PresetValue: PresetValue.geometry
+// (point/line/area/etc) was replaced with appliesTo (observation/track) in #12
+type ExpectedCategory = Omit<Expected<PresetValue>, 'geometry'> & {
+	appliesTo: ('observation' | 'track')[]
+}
+Expect<ExtendsStrict<CategoryOutput, ExpectedCategory>>
 Expect<ExtendsStrict<FieldOutput, Expected<FieldValue>>>
 
 function Expect<T extends true>() {}


### PR DESCRIPTION
- Adds `npm run lint` script
- Runs lint during CI so we don't have unformatted code or tS errors commited
- Fixes error identified in #52 